### PR TITLE
Fix: `package.json` missing fields

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -9,7 +9,9 @@
     "files": [
         "icons/"
     ],
+    "main": "./icons/index.js",
     "module": "./icons/esm/index.js",
+    "types": "./icons/index.d.ts",
     "publishConfig": {
         "access": "public"
     },

--- a/vue/package.json
+++ b/vue/package.json
@@ -9,6 +9,7 @@
     "files": [
         "icons/"
     ],
+    "main": "./icons/index.js",
     "module": "./icons/esm/index.js",
     "publishConfig": {
         "access": "public"

--- a/vue3/package.json
+++ b/vue3/package.json
@@ -9,6 +9,7 @@
     "files": [
         "icons/"
     ],
+    "main": "./icons/index.js",
     "module": "./icons/esm/index.js",
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Some fields were missing from the `package.json` files and this lead to "Missing package" error when running.

I added the `main` field to all `package.json` files for frameworks, as well as a `types` field for the react package.